### PR TITLE
Enable automatic terraform apply workflow

### DIFF
--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -1,12 +1,11 @@
 name: Terraform Apply with Slack Approval
 
 on:
-  # Disabled automatic runs to prevent lock conflicts
-  # push:
-  #   branches: [main]
-  #   paths:
-  #     - '**.tf'
-  #     - '**.tfvars'
+  push:
+    branches: [main]
+    paths:
+      - '**.tf'
+      - '**.tfvars'
   workflow_dispatch:
     inputs:
       force_apply:


### PR DESCRIPTION
This PR re-enables automatic terraform apply when changes are merged to main.

## Changes
- Uncomments the push trigger in terraform-apply.yml
- Workflow will now run automatically when .tf or .tfvars files are changed on main

## Benefits
- No need to manually trigger workflow after merge
- Maintains all safety features (compliance checks, Slack approval)
- Manual dispatch still available for emergency changes

## Workflow behavior
1. PR is merged to main
2. Terraform apply workflow triggers automatically
3. Compliance checks run first
4. Slack approval requested for changes
5. Final compliance check before apply
6. Changes are applied to infrastructure