### PR TITLE
Fix load balancer configuration with autoneg controller

### DIFF
--- a/projects/non-prod/terragrunt.hcl
+++ b/projects/non-prod/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/u2i/u2i-terraform-modules.git//webapp-project?ref=v1.28.0"
+  source = "git::https://github.com/u2i/u2i-terraform-modules.git//webapp-project?ref=v1.29.0"
 }
 
 inputs = {

--- a/projects/non-prod/terragrunt.hcl
+++ b/projects/non-prod/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/u2i/u2i-terraform-modules.git//webapp-project?ref=v1.29.0"
+  source = "git::https://github.com/u2i/u2i-terraform-modules.git//webapp-project?ref=v1.32.0"
 }
 
 inputs = {

--- a/projects/non-prod/terragrunt.hcl
+++ b/projects/non-prod/terragrunt.hcl
@@ -4,7 +4,7 @@ include "root" {
 }
 
 terraform {
-  source = "git::https://github.com/u2i/u2i-terraform-modules.git//webapp-project?ref=v1.25.0"
+  source = "git::https://github.com/u2i/u2i-terraform-modules.git//webapp-project?ref=v1.28.0"
 }
 
 inputs = {
@@ -15,4 +15,5 @@ inputs = {
   primary_region  = "europe-west1"
   github_org      = "u2i"
   github_repo     = "webapp-team-infrastructure"
+  gke_project_id  = "u2i-tenant-webapp"
 }


### PR DESCRIPTION
## Summary
- Fix health check port from 80 to 8080 to match pod configuration
- Add autoneg controller annotation to automatically attach NEGs to backend service
- Document the fixes and architecture

## Changes
- Updated `k8s-clean/overlays/nonprod/config-connector-resources.yaml` to use correct health check port
- Added `controller.autoneg.dev/neg` annotation to service for automatic NEG attachment
- Created documentation in `docs/load-balancer-fixes.md`

## Testing
The webapp is now accessible at https://dev.webapp.u2i.dev/

## Related
- Terraform modules updated to v1.29.0 to deploy autoneg controller with Workload Identity
- No service account keys required - everything uses Workload Identity

🤖 Generated with [Claude Code](https://claude.ai/code)